### PR TITLE
JsonApi relationships data accessible from attributes now.

### DIFF
--- a/lib/her/json_api/model.rb
+++ b/lib/her/json_api/model.rb
@@ -1,7 +1,7 @@
 module Her
   module JsonApi
     module Model
-      
+
       def self.included(klass)
         klass.class_eval do
           include Her::Model
@@ -15,13 +15,15 @@ module Her
           method_for :update, :patch
 
           @type = name.demodulize.tableize
-          
+
           def self.parse(data)
-            data.fetch(:attributes).merge(data.slice(:id))
+            data.fetch(:attributes)
+                .merge(data.slice(:id))
+                .merge(data.slice(:relationships))
           end
 
           def self.to_params(attributes, changes={})
-            request_data = { type: @type }.tap { |request_body| 
+            request_data = { type: @type }.tap { |request_body|
               attrs = attributes.dup.symbolize_keys.tap { |filtered_attributes|
                 if her_api.options[:send_only_modified_attributes]
                   filtered_attributes = changes.symbolize_keys.keys.inject({}) do |hash, attribute|


### PR DESCRIPTION
relationships data was not available, so with Her::JsonApi::Model is
not possible to create relations between models.
