### PR TITLE
correctly dup objects

### DIFF
--- a/lib/her/model/associations.rb
+++ b/lib/her/model/associations.rb
@@ -25,6 +25,15 @@ module Her
         send(association_name) if has_association?(association_name)
       end
 
+      # @private
+      def clear_associations
+        self.class.association_names.each do |association|
+          cached_name = :"@_her_association_#{association}"
+          instance_variable_set(cached_name, nil) if instance_variable_defined?(cached_name)
+          attributes.delete(association)
+        end
+      end
+
       module ClassMethods
         # Return @_her_associations, lazily initialized with copy of the
         # superclass' her_associations, or an empty hash.

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -35,6 +35,18 @@ module Her
         run_callbacks :initialize
       end
 
+      # @private
+      def initialize_dup(other)
+        @_her_attributes = @_her_attributes.dup
+        @_her_attributes[self.class.primary_key] = nil
+        run_callbacks :initialize
+
+        clear_associations
+        @destroyed   = false
+
+        super
+      end
+
       # Handles missing methods
       #
       # @private

--- a/lib/her/model/base.rb
+++ b/lib/her/model/base.rb
@@ -28,6 +28,17 @@ module Her
       def singularized_resource_name
         self.class.name.split('::').last.tableize.singularize
       end
+
+      # @private
+      def initialize_dup(other)
+        @_her_attributes = @_her_attributes.dup
+        @_her_attributes[self.class.primary_key] = nil
+
+        @new_record  = true
+        @destroyed   = false
+
+        super
+      end
     end
   end
 end

--- a/lib/her/model/base.rb
+++ b/lib/her/model/base.rb
@@ -28,17 +28,6 @@ module Her
       def singularized_resource_name
         self.class.name.split('::').last.tableize.singularize
       end
-
-      # @private
-      def initialize_dup(other)
-        @_her_attributes = @_her_attributes.dup
-        @_her_attributes[self.class.primary_key] = nil
-
-        @new_record  = true
-        @destroyed   = false
-
-        super
-      end
     end
   end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -42,4 +42,12 @@ describe Her::Model do
     specify { expect(subject[:name]).to eq("Tobias Fünke") }
     specify { expect(subject[:comments].first.body).to eq("They're having a FIRESALE?") }
   end
+
+  describe :duplication do
+    it "should not modify the original object" do
+      dup_subject = subject.dup
+      dup_subject.name = "Maeby Fünke"
+      expect(subject.name).to eq("Tobias Fünke")
+    end
+  end
 end

--- a/spec/model_spec.rb
+++ b/spec/model_spec.rb
@@ -49,5 +49,10 @@ describe Her::Model do
       dup_subject.name = "Maeby Fünke"
       expect(subject.name).to eq("Tobias Fünke")
     end
+
+    it "should not have associations" do
+      dup_subject = subject.dup
+      expect(dup_subject.comments.size).to eq(0)
+    end
   end
 end


### PR DESCRIPTION
Attempting to fix #355 

After calling `dup` on an object, changes made to either object would be applied to both objects. This fixes that issue so that both objects are independent of one another.  