### PR TITLE
Replace usage of HashWithIndifferentAccess with a naive implementation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,6 @@ gemspec
 
 if RbConfig::CONFIG['RUBY_PROGRAM_VERSION'] && RbConfig::CONFIG['RUBY_PROGRAM_VERSION'] >= '1.9.3'
   gem 'activemodel', '>= 3.2.0'
-  gem 'activesupport', '>= 3.2.0'
 else
   gem 'activemodel', '~> 3.2.0'
-  gem 'activesupport', '~> 3.2.0'
 end

--- a/lib/hash_with_naive_indifferent_access.rb
+++ b/lib/hash_with_naive_indifferent_access.rb
@@ -1,0 +1,21 @@
+class HashWithNaiveIndifferentAccess < Hash
+  def [](key)
+    super(key.to_s)
+  end
+
+  def []=(key, value)
+    super(key.to_s, value)
+  end
+
+  def merge(other)
+    super(other.transform_keys(&:to_s))
+  end
+
+  def merge!(other)
+    super(other.transform_keys(&:to_s))
+  end
+
+  def include?(key)
+    super(key.to_s)
+  end
+end

--- a/lib/her.rb
+++ b/lib/her.rb
@@ -6,11 +6,14 @@ require "active_support"
 require "active_support/inflector"
 require "active_support/core_ext/hash"
 
+require "hash_with_naive_indifferent_access"
+
 require "her/model"
 require "her/api"
 require "her/middleware"
 require "her/errors"
 require "her/collection"
+
 
 module Her
   module JsonApi

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -97,7 +97,7 @@ module Her
         # attributes exist, and assumes that if the instance variable
         # `@attributes` exists on the instance, it is because they are
         # `ActiveRecord` attributes.
-        @_her_attributes ||= HashWithIndifferentAccess.new
+        @_her_attributes ||= HashWithNaiveIndifferentAccess.new
       end
 
       # Handles returning true for the accessible attributes

--- a/spec/hash_with_naive_indifferent_access_spec.rb
+++ b/spec/hash_with_naive_indifferent_access_spec.rb
@@ -1,0 +1,26 @@
+require "spec_helper"
+require "byebug"
+
+describe HashWithNaiveIndifferentAccess do
+  subject { HashWithNaiveIndifferentAccess.new.tap { |h| h[:key] = 'value' } }
+
+  describe "#[:key], #[:key]=" do
+    subject { super()[:key] }
+    it { is_expected.to eq('value') }
+  end
+
+  describe "#merge" do
+    subject { super().merge(:new_key => 'new value')['new_key'] }
+    it { is_expected.to eq('new value') }
+  end
+
+  describe "#merge!" do
+    subject { super().merge!(:new_key => 'new value')['new_key'] }
+    it { is_expected.to eq('new value') }
+  end
+
+  describe "#include?" do
+    subject { super().include?(:key) }
+    it { is_expected.to eq(true) }
+  end
+end


### PR DESCRIPTION
This improves performance, and removes the dependency on ActiveSupport.