### PR TITLE
Fix infinite loop when parsing nested associations

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -63,7 +63,7 @@ module Her
         def embeded_params(attributes)
           associations.keys.each_with_object({}) do |key, hash|
             associations[key].flatten.each do |definition|
-              next if hash[definition[:data_key]].present? && key == :belongs_to
+              next if hash[definition[:data_key]].present? && key.to_sym == :belongs_to
               embeded_association(attributes, definition, hash)
             end
           end

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -63,7 +63,7 @@ module Her
         def embeded_params(attributes)
           associations.keys.each_with_object({}) do |key, hash|
             associations[key].flatten.each do |definition|
-              next if hash[definition[:data_key]].present? && key.to_sym == :belongs_to
+              next if attributes[definition[:data_key]].present? && key == :belongs_to
               embeded_association(attributes, definition, hash)
             end
           end

--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -61,15 +61,23 @@ module Her
 
         # @private
         def embeded_params(attributes)
-          associations.values.flatten.each_with_object({}) do |definition, hash|
-            value = case association = attributes[definition[:name]]
-                    when Her::Collection, Array
-                      association.map { |a| a.to_params }.reject(&:empty?)
-                    when Her::Model
-                      association.to_params
-                    end
-            hash[definition[:data_key]] = value if value.present?
+          associations.keys.each_with_object({}) do |key, hash|
+            associations[key].flatten.each do |definition|
+              next if hash[definition[:data_key]].present? && key == :belongs_to
+              embeded_association(attributes, definition, hash)
+            end
           end
+        end
+
+        # @private
+        def embeded_association(attributes, definition, hash)
+          value = case association = attributes[definition[:name]]
+                  when Her::Collection, Array
+                    association.map { |a| a.to_params }.reject(&:empty?)
+                  when Her::Model
+                    association.to_params
+                  end
+          hash[definition[:data_key]] = value if value.present?
         end
 
         # Return or change the value of `include_root_in_json`


### PR DESCRIPTION
It appears [with this commit](https://github.com/remi/her/commit/69406cffae856922210f069a083df99a44aa5247?branch=69406cffae856922210f069a083df99a44aa5247&diff=split#diff-9f46c6432f36a5642681207c26cf15f8R57) a potential infinite loop was introduced if models defined both has_many/belongs_to.  

To mitigate this, I've added a straightforward check for `belongs_to` to no-op if the association is already defined on the resulting object.