### PR TITLE
Fix infinite loop when parsing nested associations

### DIFF
--- a/lib/her/model/parse.rb
+++ b/lib/her/model/parse.rb
@@ -61,15 +61,23 @@ module Her
 
         # @private
         def embeded_params(attributes)
-          associations.values.flatten.each_with_object({}) do |definition, hash|
-            value = case association = attributes[definition[:name]]
-                    when Her::Collection, Array
-                      association.map { |a| a.to_params }.reject(&:empty?)
-                    when Her::Model
-                      association.to_params
-                    end
-            hash[definition[:data_key]] = value if value.present?
+          associations.keys.each_with_object({}) do |key, hash|
+            associations[key].flatten.each do |definition|
+              next if attributes[definition[:data_key]].present? && key.to_sym == :belongs_to
+              embeded_association(attributes, definition, hash)
+            end
           end
+        end
+
+        # @private
+        def embeded_association(attributes, definition, hash)
+          value = case association = attributes[definition[:name]]
+                  when Her::Collection, Array
+                    association.map { |a| a.to_params }.reject(&:empty?)
+                  when Her::Model
+                    association.to_params
+                  end
+          hash[definition[:data_key]] = value if value.present?
         end
 
         # Return or change the value of `include_root_in_json`

--- a/spec/model/associations_spec.rb
+++ b/spec/model/associations_spec.rb
@@ -369,7 +369,7 @@ describe Her::Model::Associations do
       end
 
       it "includes belongs_to relationship in params by default" do
-        expect(user_params[:organization]).to be_kind_of(Hash)
+        expect(user_params[:organization]).to be_a(Foo::Organization)
         expect(user_params[:organization]).not_to be_empty
       end
     end
@@ -684,7 +684,7 @@ describe Her::Model::Associations do
       end
 
       it "includes belongs_to relationship in params by default" do
-        expect(user_params[:organization]).to be_kind_of(Hash)
+        expect(user_params[:organization]).to be_a(Foo::Organization)
         expect(user_params[:organization]).not_to be_empty
       end
     end


### PR DESCRIPTION
It appears [with this commit](https://github.com/remi/her/commit/69406cffae856922210f069a083df99a44aa5247?branch=69406cffae856922210f069a083df99a44aa5247&diff=split#diff-9f46c6432f36a5642681207c26cf15f8R57) a potential infinite loop was introduced if models defined both has_many/belongs_to.  

To mitigate this, I've added a straightforward check for `belongs_to` to no-op if the association is already defined on the resulting object.  Also, sorry for the previous PR!  Moved this under my company's organization for easy access to the rest of my team.