### PR TITLE
has_many_association: Deal with empty 204 status code

### DIFF
--- a/lib/her/model/associations/association.rb
+++ b/lib/her/model/associations/association.rb
@@ -49,8 +49,21 @@ module Her
           return @opts[:default].try(:dup) if @parent.new?
 
           path = build_association_path -> { "#{@parent.request_path(@params)}#{@opts[:path]}" }
-          @klass.get(path, @params).tap do |result|
+
+          # XXX: Depending on the case, we route through fetching a collection
+          # or a single resource (has_one/belongs_to)
+          request_association(path, @params).tap do |result|
             @cached_result = result unless @params.any?
+            return result
+          end
+        end
+
+        # @private
+        def request_association(path, params)
+          if @opts[:default].is_a? Array
+            @klass.get_collection(path, @params)
+          else
+            @klass.get(path, @params)
           end
         end
 

--- a/lib/her/model/attributes.rb
+++ b/lib/her/model/attributes.rb
@@ -179,9 +179,14 @@ module Her
         #
         # @private
         def instantiate_collection(klass, parsed_data = {})
-          records = klass.extract_array(parsed_data).map do |record|
+          raw_data = klass.extract_array(parsed_data)
+
+          # XXX: This method should always return a collection
+          raw_data = [] if raw_data.blank?
+          records = raw_data.map do |record|
             instantiate_record(klass, data: record)
           end
+
           Her::Collection.new(records, parsed_data[:metadata], parsed_data[:errors])
         end
 


### PR DESCRIPTION
If you register a relationship as a `has_many` and you this resource
endpoint return a 204 we should handle this gracefully, by returning a
empty array. This patch leverages the default return type defined on the
relationship (`@opts[:default]`) to construct which sort of response it
would expect (`get_collection` or a regular `get`).

The default parser, is dumb and therefore cannot distinguish if when it
receives a 204 it should transform that into a hash or an array, and
always convert the response into a empty hash. So, on the
attributes.rb method called `instantiate_collection` when we stumble
upon a empty hash we always convert into an empty array.